### PR TITLE
fix(#13): conectar edit_review a template propio de resenas

### DIFF
--- a/movies/templates/movies/reviews.html
+++ b/movies/templates/movies/reviews.html
@@ -129,7 +129,7 @@
                 <!-- Botones de gestión: editar y eliminar -->
                 <div class="flex items-center gap-3 mt-4">
                     <!-- Editar redirige al formulario de edición -->
-                    <a href="{% url 'edit_review' review.id %}"
+                   <a href="{% url 'edit_review' review.id %}"
                       class="flex items-center gap-1 text-sm text-primary hover:text-primary-container transition-colors">
                         <span class="material-symbols-outlined text-base">edit</span>
                         Editar

--- a/movies/views.py
+++ b/movies/views.py
@@ -143,15 +143,15 @@ def edit_review(request, review_id):
             review.title = form.cleaned_data['title']
             review.review = form.cleaned_data['review']
             review.save()
-            return HttpResponse(status=204, headers={'HX-Trigger': 'listChanged'})
+            return redirect(f'/movies/movie_reviews/{review.movie.id}/')
     else:
         form = MovieReviewForm(initial={
             'rating': review.rating,
             'title': review.title,
             'review': review.review
         })
-        return render(request, 'movies/movie_review_form.html', {
-            'movie_review_form': form,
+        return render(request, 'movies/review_form.html', {
+            'form': form,
             'movie': review.movie,
             'review': review
         })


### PR DESCRIPTION
-Se cambia edit_review para usar review_form.html en lugar de movie_review_form.html 
-Se actualiza contexto de form para coincidir con el template 
-Se redirige a pagina de resenas al guardar cambios

Closes #13
